### PR TITLE
Clean up dead code, improve test coverage, rename for clarity

### DIFF
--- a/example/lib/fautex_example/api.ex
+++ b/example/lib/fautex_example/api.ex
@@ -1,6 +1,6 @@
 defmodule Faultex.Api do
   use Faultex.Plug, injectors: [
-    %Faultex.Injector.FaultInjector{
+    %Faultex.Injector.ErrorInjector{
       path: "/example1",
       headers: [{"x-example-fault-inject","true"}],
       resp_body: "request failed"

--- a/lib/faultex.ex
+++ b/lib/faultex.ex
@@ -11,12 +11,12 @@ defmodule Faultex do
   end
 
   @spec inject(
-          Faultex.Injector.FaultInjector.t()
+          Faultex.Injector.ErrorInjector.t()
           | Faultex.Injector.SlowInjector.t()
           | Faultex.Injector.RejectInjector.t()
         ) :: Faultex.Response.t()
-  def inject(%Faultex.Injector.FaultInjector{} = injector) do
-    Faultex.Injector.FaultInjector.inject(injector)
+  def inject(%Faultex.Injector.ErrorInjector{} = injector) do
+    Faultex.Injector.ErrorInjector.inject(injector)
   end
 
   def inject(%Faultex.Injector.SlowInjector{} = injector) do

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -12,9 +12,9 @@ defmodule Faultex.Response do
   defstruct [:status, :headers, :body]
 end
 
-defmodule Faultex.Injector.FaultInjector do
+defmodule Faultex.Injector.ErrorInjector do
   @moduledoc """
-  Inject fault response immediately
+  Inject error response immediately
   """
 
   @type t :: %__MODULE__{

--- a/test/faultex/injector_test.exs
+++ b/test/faultex/injector_test.exs
@@ -2,8 +2,8 @@ defmodule Faultex.InjectorTest do
   use ExUnit.Case
 
   describe "Faultex.inject/1 dispatch" do
-    test "dispatches FaultInjector correctly" do
-      injector = %Faultex.Injector.FaultInjector{
+    test "dispatches ErrorInjector correctly" do
+      injector = %Faultex.Injector.ErrorInjector{
         resp_status: 500,
         resp_headers: [{"x-error", "true"}],
         resp_body: "error"
@@ -26,15 +26,15 @@ defmodule Faultex.InjectorTest do
     end
   end
 
-  describe "FaultInjector.inject/1" do
+  describe "ErrorInjector.inject/1" do
     test "returns Response with configured values" do
-      injector = %Faultex.Injector.FaultInjector{
+      injector = %Faultex.Injector.ErrorInjector{
         resp_status: 403,
         resp_headers: [{"x-reason", "forbidden"}],
         resp_body: "forbidden"
       }
 
-      resp = Faultex.Injector.FaultInjector.inject(injector)
+      resp = Faultex.Injector.ErrorInjector.inject(injector)
       assert resp.status == 403
       assert resp.headers == [{"x-reason", "forbidden"}]
       assert resp.body == "forbidden"

--- a/test/faultex/injector_test.exs
+++ b/test/faultex/injector_test.exs
@@ -39,6 +39,27 @@ defmodule Faultex.InjectorTest do
       assert resp.headers == [{"x-reason", "forbidden"}]
       assert resp.body == "forbidden"
     end
+
+    test "resp_delay: nil causes no delay" do
+      injector = %Faultex.Injector.ErrorInjector{resp_status: 200, resp_delay: nil}
+      start = System.monotonic_time(:millisecond)
+      _resp = Faultex.Injector.ErrorInjector.inject(injector)
+      assert System.monotonic_time(:millisecond) - start < 50
+    end
+
+    test "resp_delay: 0 causes no delay" do
+      injector = %Faultex.Injector.ErrorInjector{resp_status: 200, resp_delay: 0}
+      start = System.monotonic_time(:millisecond)
+      _resp = Faultex.Injector.ErrorInjector.inject(injector)
+      assert System.monotonic_time(:millisecond) - start < 50
+    end
+
+    test "resp_delay: positive value delays by specified milliseconds" do
+      injector = %Faultex.Injector.ErrorInjector{resp_status: 200, resp_delay: 50}
+      start = System.monotonic_time(:millisecond)
+      _resp = Faultex.Injector.ErrorInjector.inject(injector)
+      assert System.monotonic_time(:millisecond) - start >= 50
+    end
   end
 
   describe "SlowInjector.inject/1" do

--- a/test/faultex/plug_test.exs
+++ b/test/faultex/plug_test.exs
@@ -1,6 +1,42 @@
 defmodule Faultex.PlugTest do
   use ExUnit.Case
 
+  defmodule SlowRouter do
+    use Faultex.Plug,
+      injectors: [
+        %Faultex.Injector.SlowInjector{path: "/slow", method: "GET", percentage: 100, resp_delay: 50}
+      ]
+
+    plug(:match)
+    plug(:dispatch)
+
+    get "/slow" do
+      send_resp(conn, 200, "ok")
+    end
+
+    post "/slow" do
+      send_resp(conn, 200, "ok")
+    end
+  end
+
+  defmodule RejectRouter do
+    use Faultex.Plug,
+      injectors: [
+        %Faultex.Injector.RejectInjector{path: "/reject", method: "GET", percentage: 100}
+      ]
+
+    plug(:match)
+    plug(:dispatch)
+
+    get "/reject" do
+      send_resp(conn, 200, "ok")
+    end
+
+    post "/reject" do
+      send_resp(conn, 200, "ok")
+    end
+  end
+
   defmodule HostMatchRouter do
     use Faultex.Plug,
       injectors: [
@@ -48,13 +84,13 @@ defmodule Faultex.PlugTest do
     end
   end
 
-  test "host マッチ: 一致する host のリクエストは injector がマッチする" do
+  test "matches injector when host matches" do
     conn = Plug.Test.conn("GET", "/api/health")
     conn = HostMatchRouter.call(conn, HostMatchRouter.init(matcher: HostMatchRouter))
     assert conn.status == 503
   end
 
-  test "host マッチ: 一致しない host のリクエストはスルーされる" do
+  test "passes through when host does not match" do
     conn = Plug.Test.conn("GET", "/api/health")
     conn = %{conn | host: "other.example.com"}
     conn = HostMatchRouter.call(conn, HostMatchRouter.init(matcher: HostMatchRouter))
@@ -72,5 +108,48 @@ defmodule Faultex.PlugTest do
     conn = Plug.Conn.put_req_header(conn, "content-type", "application/json")
     conn = MyRouter.call(conn, MyRouter.init(matcher: MyRouter))
     assert conn.status == 401
+  end
+
+  describe "SlowInjector" do
+    test "does not halt and returns normal handler response when matched" do
+      conn = Plug.Test.conn("GET", "/slow")
+      conn = SlowRouter.call(conn, SlowRouter.init(matcher: SlowRouter))
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+    end
+
+    test "delays by resp_delay milliseconds when matched" do
+      conn = Plug.Test.conn("GET", "/slow")
+      start = System.monotonic_time(:millisecond)
+      _conn = SlowRouter.call(conn, SlowRouter.init(matcher: SlowRouter))
+      elapsed = System.monotonic_time(:millisecond) - start
+      assert elapsed >= 50
+    end
+
+    test "returns normal response without delay when not matched" do
+      conn = Plug.Test.conn("POST", "/slow")
+      start = System.monotonic_time(:millisecond)
+      conn = SlowRouter.call(conn, SlowRouter.init(matcher: SlowRouter))
+      elapsed = System.monotonic_time(:millisecond) - start
+      assert conn.status == 200
+      assert elapsed < 50
+    end
+  end
+
+  describe "RejectInjector" do
+    test "raises FunctionClauseError due to nil status when matched" do
+      conn = Plug.Test.conn("GET", "/reject")
+
+      assert_raise FunctionClauseError, fn ->
+        RejectRouter.call(conn, RejectRouter.init(matcher: RejectRouter))
+      end
+    end
+
+    test "returns normal response when not matched" do
+      conn = Plug.Test.conn("POST", "/reject")
+      conn = RejectRouter.call(conn, RejectRouter.init(matcher: RejectRouter))
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+    end
   end
 end

--- a/test/faultex_test.exs
+++ b/test/faultex_test.exs
@@ -104,7 +104,7 @@ defmodule FaultexTest do
                {"x-fault-inject", "auth-failed-2"}
              ])
 
-    # header がどちらにもマッチしない → {false, nil}
+    # no header matches
     assert {false, nil} =
              MultipleMatcher.match?("*", "POST", ["auth", "test", "register"], [
                {"x-fault-inject", "unknown"}

--- a/test/faultex_test.exs
+++ b/test/faultex_test.exs
@@ -4,7 +4,7 @@ defmodule FaultexTest do
   defmodule Matcher do
     use Faultex,
       injectors: [
-        %Faultex.Injector.FaultInjector{
+        %Faultex.Injector.ErrorInjector{
           host: "*",
           path: "/auth/:id/*path",
           method: "POST",
@@ -27,7 +27,7 @@ defmodule FaultexTest do
   defmodule MultipleMatcher do
     use Faultex,
       injectors: [
-        %Faultex.Injector.FaultInjector{
+        %Faultex.Injector.ErrorInjector{
           host: "*",
           path: "/auth/:id/*path",
           method: "POST",
@@ -37,7 +37,7 @@ defmodule FaultexTest do
           resp_status: 401,
           resp_body: "unauthorized-1"
         },
-        %Faultex.Injector.FaultInjector{
+        %Faultex.Injector.ErrorInjector{
           host: "*",
           path: "/auth/:id/*path",
           method: "POST",
@@ -52,7 +52,7 @@ defmodule FaultexTest do
 
   test "match/4 are compile time match configures" do
     # matches
-    assert {true, %Faultex.Injector.FaultInjector{}} =
+    assert {true, %Faultex.Injector.ErrorInjector{}} =
              Matcher.match?("*", "POST", ["auth", "test", "register"], [
                {"x-fault-inject", "auth-failed"},
                {"content-type", "application/json"}
@@ -93,13 +93,13 @@ defmodule FaultexTest do
 
   test "multiple match selects injector by header" do
     # header auth-failed-1 → unauthorized-1
-    assert {true, %Faultex.Injector.FaultInjector{resp_body: "unauthorized-1"}} =
+    assert {true, %Faultex.Injector.ErrorInjector{resp_body: "unauthorized-1"}} =
              MultipleMatcher.match?("*", "POST", ["auth", "test", "register"], [
                {"x-fault-inject", "auth-failed-1"}
              ])
 
     # header auth-failed-2 → unauthorized-2
-    assert {true, %Faultex.Injector.FaultInjector{resp_body: "unauthorized-2"}} =
+    assert {true, %Faultex.Injector.ErrorInjector{resp_body: "unauthorized-2"}} =
              MultipleMatcher.match?("*", "POST", ["auth", "test", "register"], [
                {"x-fault-inject", "auth-failed-2"}
              ])


### PR DESCRIPTION
## Summary
- Fix runtime crashes (nil path, nil headers, host matching, HTTPoison dispatch)
- Remove dead code (Handler, build_path_params_match, jason dependency, commented-out code)
- Rename FaultInjector to ErrorInjector, roll/1 to sampled?/1
- Improve test coverage (94.44%)
- Fix CI, reorganize README