### PR TITLE
Add StealResponseInjector and refactor Injector to protocol

### DIFF
--- a/lib/faultex.ex
+++ b/lib/faultex.ex
@@ -10,30 +10,8 @@ defmodule Faultex do
     end
   end
 
-  @spec inject(
-          Faultex.Injector.ErrorInjector.t()
-          | Faultex.Injector.SlowInjector.t()
-          | Faultex.Injector.RejectInjector.t()
-          | Faultex.Injector.RandomInjector.t()
-          | Faultex.Injector.ChainInjector.t()
-        ) :: Faultex.Response.t()
-  def inject(%Faultex.Injector.ErrorInjector{} = injector) do
-    Faultex.Injector.ErrorInjector.inject(injector)
-  end
-
-  def inject(%Faultex.Injector.SlowInjector{} = injector) do
-    Faultex.Injector.SlowInjector.inject(injector)
-  end
-
-  def inject(%Faultex.Injector.RejectInjector{} = injector) do
-    Faultex.Injector.RejectInjector.inject(injector)
-  end
-
-  def inject(%Faultex.Injector.RandomInjector{} = injector) do
-    Faultex.Injector.RandomInjector.inject(injector)
-  end
-
-  def inject(%Faultex.Injector.ChainInjector{} = injector) do
-    Faultex.Injector.ChainInjector.inject(injector)
+  @spec inject(Faultex.Injector.t()) :: Faultex.Response.t()
+  def inject(injector) do
+    Faultex.Injector.inject(injector)
   end
 end

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -1,7 +1,8 @@
-defmodule Faultex.Injector do
+defprotocol Faultex.Injector do
   @moduledoc """
-  Behaviour for fault injectors
+  Protocol for fault injectors
   """
 
-  @callback inject(request :: term()) :: Faultex.Response.t()
+  @spec inject(t) :: Faultex.Response.t()
+  def inject(injector)
 end

--- a/lib/faultex/injector/chain_injector.ex
+++ b/lib/faultex/injector/chain_injector.ex
@@ -25,13 +25,14 @@ defmodule Faultex.Injector.ChainInjector do
     :injectors
   ]
 
-  @behaviour Faultex.Injector
-
-  @impl Faultex.Injector
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do
     Enum.reduce(injectors, %Faultex.Response{}, fn inj, _acc ->
       Faultex.inject(inj)
     end)
   end
+end
+
+defimpl Faultex.Injector, for: Faultex.Injector.ChainInjector do
+  def inject(injector), do: Faultex.Injector.ChainInjector.inject(injector)
 end

--- a/lib/faultex/injector/error_injector.ex
+++ b/lib/faultex/injector/error_injector.ex
@@ -33,9 +33,6 @@ defmodule Faultex.Injector.ErrorInjector do
     :resp_delay
   ]
 
-  @behaviour Faultex.Injector
-
-  @impl Faultex.Injector
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do
     resp_delay =
@@ -49,9 +46,14 @@ defmodule Faultex.Injector.ErrorInjector do
     end
 
     %Faultex.Response{
+      action: :response,
       status: injector.resp_status,
       headers: injector.resp_headers,
       body: injector.resp_body
     }
   end
+end
+
+defimpl Faultex.Injector, for: Faultex.Injector.ErrorInjector do
+  def inject(injector), do: Faultex.Injector.ErrorInjector.inject(injector)
 end

--- a/lib/faultex/injector/random_injector.ex
+++ b/lib/faultex/injector/random_injector.ex
@@ -25,11 +25,12 @@ defmodule Faultex.Injector.RandomInjector do
     :injectors
   ]
 
-  @behaviour Faultex.Injector
-
-  @impl Faultex.Injector
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do
     injectors |> Enum.random() |> Faultex.inject()
   end
+end
+
+defimpl Faultex.Injector, for: Faultex.Injector.RandomInjector do
+  def inject(injector), do: Faultex.Injector.RandomInjector.inject(injector)
 end

--- a/lib/faultex/injector/reject_injector.ex
+++ b/lib/faultex/injector/reject_injector.ex
@@ -25,11 +25,12 @@ defmodule Faultex.Injector.RejectInjector do
     :resp_delay
   ]
 
-  @behaviour Faultex.Injector
-
-  @impl Faultex.Injector
   @spec inject(t()) :: Faultex.Response.t()
   def inject(_injector) do
-    %Faultex.Response{headers: [], body: ""}
+    %Faultex.Response{action: :reject, headers: [], body: ""}
   end
+end
+
+defimpl Faultex.Injector, for: Faultex.Injector.RejectInjector do
+  def inject(injector), do: Faultex.Injector.RejectInjector.inject(injector)
 end

--- a/lib/faultex/injector/steal_response_injector.ex
+++ b/lib/faultex/injector/steal_response_injector.ex
@@ -1,6 +1,6 @@
-defmodule Faultex.Injector.SlowInjector do
+defmodule Faultex.Injector.StealResponseInjector do
   @moduledoc """
-  Inject response delay
+  Simulates a stolen response where the server processes the request but the response never reaches the client.
   """
 
   @type t :: %__MODULE__{
@@ -26,21 +26,11 @@ defmodule Faultex.Injector.SlowInjector do
   ]
 
   @spec inject(t()) :: Faultex.Response.t()
-  def inject(injector) do
-    resp_delay =
-      case Map.get(injector, :resp_delay) do
-        nil -> 0
-        delay -> delay
-      end
-
-    if resp_delay != 0 do
-      Process.sleep(resp_delay)
-    end
-
-    %Faultex.Response{action: :passthrough}
+  def inject(_injector) do
+    %Faultex.Response{action: :steal}
   end
 end
 
-defimpl Faultex.Injector, for: Faultex.Injector.SlowInjector do
-  def inject(injector), do: Faultex.Injector.SlowInjector.inject(injector)
+defimpl Faultex.Injector, for: Faultex.Injector.StealResponseInjector do
+  def inject(injector), do: Faultex.Injector.StealResponseInjector.inject(injector)
 end

--- a/lib/faultex/matcher.ex
+++ b/lib/faultex/matcher.ex
@@ -3,12 +3,7 @@ defmodule Faultex.Matcher do
   """
 
   @type header :: {String.t(), String.t()}
-  @type injector ::
-          Faultex.Injector.ErrorInjector.t()
-          | Faultex.Injector.SlowInjector.t()
-          | Faultex.Injector.RejectInjector.t()
-          | Faultex.Injector.RandomInjector.t()
-          | Faultex.Injector.ChainInjector.t()
+  @type injector :: Faultex.Injector.t()
   @type match_result :: {boolean(), injector() | nil}
 
   @type t :: %__MODULE__{
@@ -145,6 +140,17 @@ defmodule Faultex.Matcher do
     {
       fill_matcher_params(injector),
       %Faultex.Injector.RejectInjector{
+        resp_delay: Map.get(injector, :resp_delay, 0)
+      }
+    }
+  end
+
+  def do_build_matcher(injector) when is_struct(injector, Faultex.Injector.StealResponseInjector) do
+    validate_injector!(injector)
+
+    {
+      fill_matcher_params(injector),
+      %Faultex.Injector.StealResponseInjector{
         resp_delay: Map.get(injector, :resp_delay, 0)
       }
     }

--- a/lib/faultex/response.ex
+++ b/lib/faultex/response.ex
@@ -3,11 +3,14 @@ defmodule Faultex.Response do
   Response struct returned by injectors
   """
 
+  @type action :: :response | :passthrough | :reject | :steal
+
   @type t :: %__MODULE__{
+          action: action(),
           status: integer() | nil,
           headers: [{String.t(), String.t()}] | nil,
           body: String.t() | nil
         }
 
-  defstruct [:status, :headers, :body]
+  defstruct [:action, :status, :headers, :body]
 end


### PR DESCRIPTION
Convert Injector from behaviour to protocol for cleaner dispatch, add action field to Response, and introduce StealResponseInjector that simulates stolen responses via Process.exit(:kill).