### PR TITLE
DRY up common fields across Injector modules via __using__ macro

### DIFF
--- a/lib/faultex.ex
+++ b/lib/faultex.ex
@@ -10,7 +10,7 @@ defmodule Faultex do
     end
   end
 
-  @spec inject(Faultex.Injector.t()) :: Faultex.Response.t()
+  @spec inject(struct()) :: Faultex.Response.t()
   def inject(injector) do
     Faultex.Injector.inject(injector)
   end

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -3,14 +3,13 @@ defmodule Faultex.Injector do
   Common module for fault injectors
   """
 
-  @base_fields [:id, :disable, :host, :method, :path, :headers, :percentage]
+  @__fields__ [:id, :disable, :host, :method, :path, :headers, :percentage]
 
   defmacro __using__(opts) do
-    extra_fields = Keyword.get(opts, :fields, [])
-    all_fields = @base_fields ++ extra_fields
+    fields = @__fields__ ++ Keyword.get(opts, :fields, [])
 
     quote do
-      defstruct unquote(all_fields)
+      defstruct unquote(fields)
     end
   end
 

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -1,8 +1,19 @@
-defprotocol Faultex.Injector do
+defmodule Faultex.Injector do
   @moduledoc """
-  Protocol for fault injectors
+  Common module for fault injectors
   """
 
-  @spec inject(t) :: Faultex.Response.t()
-  def inject(injector)
+  @common_fields [:id, :disable, :host, :method, :path, :headers, :percentage]
+
+  defmacro __using__(opts) do
+    extra_fields = Keyword.get(opts, :fields, [])
+    all_fields = @common_fields ++ extra_fields
+
+    quote do
+      defstruct unquote(all_fields)
+    end
+  end
+
+  @spec inject(struct()) :: Faultex.Response.t()
+  def inject(injector), do: injector.__struct__.inject(injector)
 end

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -5,11 +5,11 @@ defmodule Faultex.Injector do
 
   @__fields__ [:id, :disable, :host, :method, :path, :headers, :percentage]
 
-  defmacro __using__(opts) do
-    fields = @__fields__ ++ Keyword.get(opts, :fields, [])
+  defmacro __using__(_) do
+    fields = @__fields__
 
     quote do
-      defstruct unquote(fields)
+      @__fields__ unquote(fields)
     end
   end
 

--- a/lib/faultex/injector.ex
+++ b/lib/faultex/injector.ex
@@ -3,11 +3,11 @@ defmodule Faultex.Injector do
   Common module for fault injectors
   """
 
-  @common_fields [:id, :disable, :host, :method, :path, :headers, :percentage]
+  @base_fields [:id, :disable, :host, :method, :path, :headers, :percentage]
 
   defmacro __using__(opts) do
     extra_fields = Keyword.get(opts, :fields, [])
-    all_fields = @common_fields ++ extra_fields
+    all_fields = @base_fields ++ extra_fields
 
     quote do
       defstruct unquote(all_fields)

--- a/lib/faultex/injector/chain_injector.ex
+++ b/lib/faultex/injector/chain_injector.ex
@@ -14,7 +14,8 @@ defmodule Faultex.Injector.ChainInjector do
           injectors: [term()]
         }
 
-  use Faultex.Injector, fields: [:injectors]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:injectors]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do

--- a/lib/faultex/injector/chain_injector.ex
+++ b/lib/faultex/injector/chain_injector.ex
@@ -14,16 +14,7 @@ defmodule Faultex.Injector.ChainInjector do
           injectors: [term()]
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :injectors
-  ]
+  use Faultex.Injector, fields: [:injectors]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do
@@ -31,8 +22,4 @@ defmodule Faultex.Injector.ChainInjector do
       Faultex.inject(inj)
     end)
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.ChainInjector do
-  def inject(injector), do: Faultex.Injector.ChainInjector.inject(injector)
 end

--- a/lib/faultex/injector/error_injector.ex
+++ b/lib/faultex/injector/error_injector.ex
@@ -18,7 +18,8 @@ defmodule Faultex.Injector.ErrorInjector do
           resp_delay: integer() | nil
         }
 
-  use Faultex.Injector, fields: [:resp_status, :resp_headers, :resp_handler, :resp_body, :resp_delay]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:resp_status, :resp_headers, :resp_handler, :resp_body, :resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do

--- a/lib/faultex/injector/error_injector.ex
+++ b/lib/faultex/injector/error_injector.ex
@@ -18,20 +18,7 @@ defmodule Faultex.Injector.ErrorInjector do
           resp_delay: integer() | nil
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :resp_status,
-    :resp_headers,
-    :resp_handler,
-    :resp_body,
-    :resp_delay
-  ]
+  use Faultex.Injector, fields: [:resp_status, :resp_headers, :resp_handler, :resp_body, :resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do
@@ -52,8 +39,4 @@ defmodule Faultex.Injector.ErrorInjector do
       body: injector.resp_body
     }
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.ErrorInjector do
-  def inject(injector), do: Faultex.Injector.ErrorInjector.inject(injector)
 end

--- a/lib/faultex/injector/random_injector.ex
+++ b/lib/faultex/injector/random_injector.ex
@@ -14,7 +14,8 @@ defmodule Faultex.Injector.RandomInjector do
           injectors: [term()]
         }
 
-  use Faultex.Injector, fields: [:injectors]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:injectors]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do

--- a/lib/faultex/injector/random_injector.ex
+++ b/lib/faultex/injector/random_injector.ex
@@ -14,23 +14,10 @@ defmodule Faultex.Injector.RandomInjector do
           injectors: [term()]
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :injectors
-  ]
+  use Faultex.Injector, fields: [:injectors]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(%__MODULE__{injectors: injectors}) do
     injectors |> Enum.random() |> Faultex.inject()
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.RandomInjector do
-  def inject(injector), do: Faultex.Injector.RandomInjector.inject(injector)
 end

--- a/lib/faultex/injector/reject_injector.ex
+++ b/lib/faultex/injector/reject_injector.ex
@@ -14,23 +14,10 @@ defmodule Faultex.Injector.RejectInjector do
           resp_delay: integer() | nil
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :resp_delay
-  ]
+  use Faultex.Injector, fields: [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(_injector) do
     %Faultex.Response{action: :reject, headers: [], body: ""}
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.RejectInjector do
-  def inject(injector), do: Faultex.Injector.RejectInjector.inject(injector)
 end

--- a/lib/faultex/injector/reject_injector.ex
+++ b/lib/faultex/injector/reject_injector.ex
@@ -14,7 +14,8 @@ defmodule Faultex.Injector.RejectInjector do
           resp_delay: integer() | nil
         }
 
-  use Faultex.Injector, fields: [:resp_delay]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(_injector) do

--- a/lib/faultex/injector/slow_injector.ex
+++ b/lib/faultex/injector/slow_injector.ex
@@ -14,16 +14,7 @@ defmodule Faultex.Injector.SlowInjector do
           resp_delay: integer() | nil
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :resp_delay
-  ]
+  use Faultex.Injector, fields: [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do
@@ -39,8 +30,4 @@ defmodule Faultex.Injector.SlowInjector do
 
     %Faultex.Response{action: :passthrough}
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.SlowInjector do
-  def inject(injector), do: Faultex.Injector.SlowInjector.inject(injector)
 end

--- a/lib/faultex/injector/slow_injector.ex
+++ b/lib/faultex/injector/slow_injector.ex
@@ -14,7 +14,8 @@ defmodule Faultex.Injector.SlowInjector do
           resp_delay: integer() | nil
         }
 
-  use Faultex.Injector, fields: [:resp_delay]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do

--- a/lib/faultex/injector/steal_response_injector.ex
+++ b/lib/faultex/injector/steal_response_injector.ex
@@ -14,23 +14,10 @@ defmodule Faultex.Injector.StealResponseInjector do
           resp_delay: integer() | nil
         }
 
-  defstruct [
-    :id,
-    :disable,
-    :host,
-    :method,
-    :path,
-    :headers,
-    :percentage,
-    :resp_delay
-  ]
+  use Faultex.Injector, fields: [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(_injector) do
     %Faultex.Response{action: :steal}
   end
-end
-
-defimpl Faultex.Injector, for: Faultex.Injector.StealResponseInjector do
-  def inject(injector), do: Faultex.Injector.StealResponseInjector.inject(injector)
 end

--- a/lib/faultex/injector/steal_response_injector.ex
+++ b/lib/faultex/injector/steal_response_injector.ex
@@ -14,7 +14,8 @@ defmodule Faultex.Injector.StealResponseInjector do
           resp_delay: integer() | nil
         }
 
-  use Faultex.Injector, fields: [:resp_delay]
+  use Faultex.Injector
+  defstruct @__fields__ ++ [:resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(_injector) do

--- a/lib/faultex/matcher.ex
+++ b/lib/faultex/matcher.ex
@@ -3,7 +3,7 @@ defmodule Faultex.Matcher do
   """
 
   @type header :: {String.t(), String.t()}
-  @type injector :: Faultex.Injector.t()
+  @type injector :: struct()
   @type match_result :: {boolean(), injector() | nil}
 
   @type t :: %__MODULE__{


### PR DESCRIPTION
## Summary

- Replace `Faultex.Injector` protocol with a regular module providing a `__using__` macro
- The macro generates `defstruct` with 7 shared fields (`:id`, `:disable`, `:host`, `:method`, `:path`, `:headers`, `:percentage`) plus module-specific fields
- Remove all `defimpl Faultex.Injector` blocks from each injector module
- Dispatch `inject/1` via `injector.__struct__.inject(injector)` instead of protocol

Closes #43