### PR TITLE
DRY up Injector common fields and clean up code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,4 @@ Application.put_env(:faultex, :disable, true)
 ## TODO
 
 - [ ] Allow `:exact` key
-- [ ] Pass path parameters to resp_handler
 - [ ] Debug log
-- [ ] RejectInjector

--- a/lib/faultex/injector/error_injector.ex
+++ b/lib/faultex/injector/error_injector.ex
@@ -13,13 +13,12 @@ defmodule Faultex.Injector.ErrorInjector do
           percentage: integer() | nil,
           resp_status: integer() | nil,
           resp_headers: [{String.t(), String.t()}] | nil,
-          resp_handler: term(),
           resp_body: String.t() | nil,
           resp_delay: integer() | nil
         }
 
   use Faultex.Injector
-  defstruct @__fields__ ++ [:resp_status, :resp_headers, :resp_handler, :resp_body, :resp_delay]
+  defstruct @__fields__ ++ [:resp_status, :resp_headers, :resp_body, :resp_delay]
 
   @spec inject(t()) :: Faultex.Response.t()
   def inject(injector) do

--- a/lib/faultex/injector/reject_injector.ex
+++ b/lib/faultex/injector/reject_injector.ex
@@ -1,6 +1,6 @@
 defmodule Faultex.Injector.RejectInjector do
   @moduledoc """
-  inject abort with empty response
+  Inject abort with empty response
   """
 
   @type t :: %__MODULE__{

--- a/lib/faultex/injector/slow_injector.ex
+++ b/lib/faultex/injector/slow_injector.ex
@@ -1,6 +1,9 @@
 defmodule Faultex.Injector.SlowInjector do
   @moduledoc """
-  Inject response delay
+  Inject response delay.
+
+  Sleeps for `resp_delay` milliseconds, then passes through to the original
+  handler (Plug pipeline or HTTPoison request) without modifying the response.
   """
 
   @type t :: %__MODULE__{

--- a/lib/faultex/matcher.ex
+++ b/lib/faultex/matcher.ex
@@ -102,27 +102,6 @@ defmodule Faultex.Matcher do
     do_build_matcher(Application.fetch_env!(:faultex, injector_id))
   end
 
-  def do_build_matcher(injector) when is_struct(injector, Faultex.Injector.ErrorInjector) do
-    validate_injector!(injector)
-
-    resp_body = Map.get(injector, :resp_body) || ""
-    resp_status = Map.get(injector, :resp_status) || 200
-    resp_headers = Map.get(injector, :resp_headers) || []
-    resp_handler = Map.get(injector, :resp_handler)
-    resp_delay = Map.get(injector, :resp_delay) || 0
-
-    {
-      fill_matcher_params(injector),
-      %Faultex.Injector.ErrorInjector{
-        resp_status: resp_status,
-        resp_body: resp_body,
-        resp_headers: resp_headers,
-        resp_delay: resp_delay,
-        resp_handler: resp_handler
-      }
-    }
-  end
-
   def do_build_matcher(injector) when is_struct(injector, Faultex.Injector.SlowInjector) do
     validate_injector!(injector)
 
@@ -194,7 +173,6 @@ defmodule Faultex.Matcher do
     resp_body = Map.get(injector, :resp_body) || ""
     resp_status = Map.get(injector, :resp_status) || 200
     resp_headers = Map.get(injector, :resp_headers) || []
-    resp_handler = Map.get(injector, :resp_handler)
     resp_delay = Map.get(injector, :resp_delay) || 0
 
     {
@@ -203,8 +181,7 @@ defmodule Faultex.Matcher do
         resp_status: resp_status,
         resp_body: resp_body,
         resp_headers: resp_headers,
-        resp_delay: resp_delay,
-        resp_handler: resp_handler
+        resp_delay: resp_delay
       }
     }
   end


### PR DESCRIPTION
## Summary
- DRY up common fields (id, disable, host, method, path, headers, percentage) across all Injector modules via `use Faultex.Injector` macro
- Remove dead `resp_handler` field from ErrorInjector
- Consolidate redundant ErrorInjector struct clause in Matcher into the existing map clause
- Improve SlowInjector moduledoc and fix RejectInjector moduledoc capitalization
- Remove completed TODO items from README